### PR TITLE
Cleanup instead of crash when loading completed achievements

### DIFF
--- a/src/AchievementsModule.cpp
+++ b/src/AchievementsModule.cpp
@@ -4789,7 +4789,7 @@ namespace cmangos_module
             Field* fields = result->Fetch();
 
             uint16 achievementId = fields[0].GetUInt16();
-            const AchievementEntry* achievement = GetAchievement(achievementId);
+            const AchievementEntry* achievement = GetAchievement(achievementId, false);
             if (!achievement) 
             {
                 // Remove non existent achievements from all characters


### PR DESCRIPTION
sometimes after transfer vanilla->tbc characters might have vanilla only stuff like self found and others. They are vanilla only and I think it's better to just auto remove it from character instead of crashing server